### PR TITLE
Fix emoji's display in editor

### DIFF
--- a/styles/simditor-emoji.css
+++ b/styles/simditor-emoji.css
@@ -28,7 +28,7 @@
   height: 1.1em;
   display: inline-block;
   margin: 0;
-  padding: 0 3px;
+  padding: 0;
   vertical-align: text-top;
   max-width: inherit;
   box-shadow: none;


### PR DESCRIPTION
By edit [padding] to fix the display.

在编辑器中显示的表情是比较长条形的，我通过检查元素修改了padding，这样在编辑器和显示页面表情的显示效果都一样了。